### PR TITLE
Clarify macOS (OS X) options in download.html

### DIFF
--- a/download.html
+++ b/download.html
@@ -298,7 +298,13 @@
           </div>
         </li>
         <li id="download-apple">
-        <h3><img src="/images/apple-logo-f4325ff1.png" />XAMPP for <strong>OS X</strong> <span>7.4.29, 8.0.19, 8.1.6, 7.4.29, 8.0.19 &amp; 8.1.6</span></h3>
+        <h3><img src="/images/apple-logo-f4325ff1.png" />XAMPP for <strong>OS X</strong> <span>native: 7.4.29, 8.0.19, &amp; 8.1.6; VM: 7.4.29, 8.0.19, &amp; 8.1.6</span></h3>
+          <p>XAMPP is provided in two forms for macOS. 
+          A <strong>native installer</strong> installs MariaDB, PHP, Perl, etc. directly onto your macOS system. It supports intel (x64) or Apple M1 (arm64) CPUs.
+          A <strong>Virtual Machine (VM)</strong> installs a virtual machine onto your macOS system. MariaDB, PHP, and Perl are installed on Linux 
+          within the virtual machine. The VM supports intel (x64) CPUs. It <strong>does not support Apple M1 (arm64) CPUs</strong> as of September 2022.
+          Learn more about the VM option at the <a href="https://www.apachefriends.org/faq_stackman.html"><strong>XAMPP-VM Frequently Asked Questions</strong></a>.  
+          </p>
           <table>
             <tr>
               <th width="25%">Version</th>
@@ -308,7 +314,7 @@
               <th width="12.5%" class="show-for-medium-up">Size</th>
             </tr>
               <tr>
-                <td rowspan="1">7.4.29 / PHP 7.4.29</td>
+                <td rowspan="1">native 7.4.29 / PHP 7.4.29</td>
                   <td class="show-for-medium-up" rowspan="1"><a data-dropdown="apple-notes-490506d81a" href="#">What's Included?</a></td>
                   
                     <td class="show-for-medium-up">
@@ -323,7 +329,7 @@
                     <td class="show-for-medium-up">163 Mb</td>
               </tr>
               <tr>
-                <td rowspan="1">8.0.19 / PHP 8.0.19</td>
+                <td rowspan="1">native 8.0.19 / PHP 8.0.19</td>
                   <td class="show-for-medium-up" rowspan="1"><a data-dropdown="apple-notes-f2023ea424" href="#">What's Included?</a></td>
                   
                     <td class="show-for-medium-up">
@@ -338,7 +344,7 @@
                     <td class="show-for-medium-up">162 Mb</td>
               </tr>
               <tr>
-                <td rowspan="1">8.1.6 / PHP 8.1.6</td>
+                <td rowspan="1">native 8.1.6 / PHP 8.1.6</td>
                   <td class="show-for-medium-up" rowspan="1"><a data-dropdown="apple-notes-4e2fb683fc" href="#">What's Included?</a></td>
                   
                     <td class="show-for-medium-up">
@@ -353,7 +359,7 @@
                     <td class="show-for-medium-up">163 Mb</td>
               </tr>
               <tr>
-                <td rowspan="1">7.4.29 / PHP 7.4.29</td>
+                <td rowspan="1">VM 7.4.29 / PHP 7.4.29</td>
                   <td class="show-for-medium-up" rowspan="1"><a data-dropdown="apple-notes-780a6dbab8" href="#">What's Included?</a></td>
                   
                     <td class="show-for-medium-up">
@@ -368,7 +374,7 @@
                     <td class="show-for-medium-up">360 Mb</td>
               </tr>
               <tr>
-                <td rowspan="1">8.0.19 / PHP 8.0.19</td>
+                <td rowspan="1">VM 8.0.19 / PHP 8.0.19</td>
                   <td class="show-for-medium-up" rowspan="1"><a data-dropdown="apple-notes-c7dc87ba74" href="#">What's Included?</a></td>
                   
                     <td class="show-for-medium-up">
@@ -383,7 +389,7 @@
                     <td class="show-for-medium-up">360 Mb</td>
               </tr>
               <tr>
-                <td rowspan="1">8.1.6 / PHP 8.1.6</td>
+                <td rowspan="1">VM 8.1.6 / PHP 8.1.6</td>
                   <td class="show-for-medium-up" rowspan="1"><a data-dropdown="apple-notes-a6fb822e71" href="#">What's Included?</a></td>
                   
                     <td class="show-for-medium-up">
@@ -422,7 +428,7 @@
               <p><strong>Includes:</strong> Apache 2.4.53, MariaDB 10.4.24, PHP 8.1.6 & PEAR + SQLite 2.8.17/3.38.5 + multibyte (mbstring) support, Perl 5.34.1, ProFTPD 1.3.6, phpMyAdmin 5.2.0, OpenSSL 1.1.1o, GD 2.2.5, Freetype2 2.4.8, libpng 1.6.37, gdbm 1.8.3, zlib 1.2.11, expat 2.0.1, Sablotron 1.0.3, libxml 2.0.1, Ming 0.4.5, Webalizer 2.23-05, pdf class 0.11.7, ncurses 5.9, pdf class 0.11.7, mod_perl 2.0.12, FreeTDS 0.91, gettext 0.19.8.1, IMAP C-Client 2007e, OpenLDAP (client) 2.4.48, mcrypt 2.5.8, mhash 0.9.9.9, cUrl 7.53.1, libxslt 1.1.33, libapreq 2.13, FPDF 1.7, ICU4C Library 66.1, APR 1.5.2, APR-utils 1.5.4</p>
             </div>
           <div class="notes" id="apple-requirements" data-dropdown-content>
-              <p>Mac OS X 10.6 or later.</p>
+              <p>For native installers: Mac OS X 10.6 or later. For VMs: Mac OS X 10.6 or later and intel (x64) CPU; not supported on M1 (arm64) CPUs.</p>
           </div>
         </li>
     </ul>


### PR DESCRIPTION
Clarify the difference between native and VM packages for macOS in download page.

Add a paragraph explaining the difference between native installation and VMs. Clearly announce that VM option does not support M1 (arm64) CPUs.  In the macOS title listing the 6 versions, add "native" and "VM" clarification. In each download entry, add "native" and "VM" clarification phrases.

In the System Requirements text, clarify that native installers require x64 or arm64, but that VM requires x64 and does not support arm64.