### PR TITLE
Add Mac VM FAQs related to arm64 non-support

### DIFF
--- a/faq_stackman.html
+++ b/faq_stackman.html
@@ -159,6 +159,16 @@
         <p>For more information, refer to the blog post at <a href="https://www.apachefriends.org/blog/new_xampp_20170628.html">https://www.apachefriends.org/blog/new_xampp_20170628.html</a>.</p>.
       </dd>
 
+      <dt>Does XAMPP-VM support Apple M1 (arm64) CPUs?</dt>
+      <dd>
+        <p>No. The components within the VM do not presently support Apple M1 (arm64) CPUs. 
+        The VM may only be used on Apple computers with intel (x64) CPUs.
+        </p>
+        <p>This is the situation as of September 2022. We hope that the VM components will support Apple M1 CPUs in the future, so that 
+        XAMPP VMs will be usable on those Apple computers as well.
+        </p>
+      </dd>
+
       <dt>How do I install XAMPP-VM for Mac OS X?</dt>
       <dd>
       <p>To install XAMPP-VM, just do the following:</p>
@@ -240,6 +250,15 @@
           </li>
         </ul>
         <p>If you get any error messages visit <a href="/community.html">our community pages</a> for help.</p>
+      </dd>
+
+      <dt>When I try to start the VM, it fails, with an error message, "cannot calculate MAC address". How do I resolve this?</dt>
+      <dd>
+        <p>This is most often a symptom of the VM running on a computer with an Apple M1 (arm64) CPU. The VM components do not support the M1 CPU
+        (as of September 2022). You can only use the VM on computers with intel (x64) CPUs. 
+        On computers with the M1 CPU, please use the XAMPP native installers instead.
+        </p>
+        <p>If you get this error messages on a computer with an intel (x64) CPU, please visit <a href="/community.html">our community pages</a> for help.</p>.
       </dd>
 
       <dt>How can I make my XAMPP-VM installation more secure?</dt>


### PR DESCRIPTION
Add two new FAQs to the faq_stackman.html page (for macOS VM FAQs):

Q: Does XAMPP-VM support Apple M1 (arm64) CPUs? A: No.

Q: When I try to start the VM, it fails, with an error message, "cannot calculate MAC address". How do I resolve this?
A1: VMs do not work on arm64 CPUs.
A2: If you see this message on intel (x64) CPUs, contact the community forums.